### PR TITLE
Implement task filtering by priority

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,7 +31,7 @@ describe('App Component Priority Integration', () => {
     render(<App />);
 
     const input = screen.getByPlaceholderText('Add a new task...');
-    const select = screen.getByRole('combobox');
+    const select = screen.getAllByRole('combobox')[0]; // First select is for adding tasks
     const addButton = screen.getByText('Add');
 
     // Add High priority
@@ -62,5 +62,62 @@ describe('App Component Priority Integration', () => {
     const lastMediumBadge = defaultMediumPriorityBadge[defaultMediumPriorityBadge.length - 1];
     expect(lastMediumBadge).toBeInTheDocument();
     expect(lastMediumBadge.style.color).toBe('orange');
+  });
+
+  it('filters tasks by priority', async () => {
+    render(<App />);
+
+    const input = screen.getByPlaceholderText('Add a new task...');
+    const select = screen.getAllByRole('combobox')[0]; // First select is for adding tasks
+    const addButton = screen.getByText('Add');
+
+    // Add High priority task
+    fireEvent.change(input, { target: { value: 'High Task' } });
+    fireEvent.change(select, { target: { value: 'high' } });
+    fireEvent.click(addButton);
+
+    // Add Low priority task
+    fireEvent.change(input, { target: { value: 'Low Task' } });
+    fireEvent.change(select, { target: { value: 'low' } });
+    fireEvent.click(addButton);
+
+    // Initial state: both tasks should be visible
+    expect(screen.getByText('High Task')).toBeInTheDocument();
+    expect(screen.getByText('Low Task')).toBeInTheDocument();
+
+    const filterSelect = screen.getByLabelText('Filter by Priority:');
+
+    // Filter by High Priority
+    fireEvent.change(filterSelect, { target: { value: 'high' } });
+    expect(screen.getByText('High Task')).toBeInTheDocument();
+    expect(screen.queryByText('Low Task')).not.toBeInTheDocument();
+
+    // Filter by Low Priority
+    fireEvent.change(filterSelect, { target: { value: 'low' } });
+    expect(screen.queryByText('High Task')).not.toBeInTheDocument();
+    expect(screen.getByText('Low Task')).toBeInTheDocument();
+
+    // Filter by All Priorities
+    fireEvent.change(filterSelect, { target: { value: 'all' } });
+    expect(screen.getByText('High Task')).toBeInTheDocument();
+    expect(screen.getByText('Low Task')).toBeInTheDocument();
+  });
+
+  it('shows message when no tasks match filter', async () => {
+    render(<App />);
+
+    const input = screen.getByPlaceholderText('Add a new task...');
+    const addButton = screen.getByText('Add');
+
+    // Add Medium priority task
+    fireEvent.change(input, { target: { value: 'Medium Task' } });
+    fireEvent.click(addButton);
+
+    const filterSelect = screen.getByLabelText('Filter by Priority:');
+
+    // Filter by High Priority (should be empty)
+    fireEvent.change(filterSelect, { target: { value: 'high' } });
+    expect(screen.queryByText('Medium Task')).not.toBeInTheDocument();
+    expect(screen.getByText('No tasks match the selected filter.')).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ export default function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [newTaskPriority, setNewTaskPriority] = useState<Priority>('medium');
+  const [filterPriority, setFilterPriority] = useState<Priority | 'all'>('all');
 
   useEffect(() => {
     setTasks(getTasks());
@@ -33,6 +34,10 @@ export default function App() {
     deleteTask(id);
     setTasks(getTasks());
   };
+
+  const filteredTasks = tasks.filter(task =>
+    filterPriority === 'all' || task.priority === filterPriority
+  );
 
   const getPriorityColor = (priority: Priority) => {
     switch (priority) {
@@ -72,11 +77,28 @@ export default function App() {
         </button>
       </form>
 
-      {tasks.length === 0 ? (
-        <p style={{ textAlign: 'center', color: '#777' }}>No tasks yet. Add one above!</p>
+      <div style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+        <label htmlFor="priority-filter" style={{ marginRight: '10px', fontSize: '14px', color: '#555' }}>Filter by Priority:</label>
+        <select
+          id="priority-filter"
+          value={filterPriority}
+          onChange={(e) => setFilterPriority(e.target.value as Priority | 'all')}
+          style={{ padding: '8px', fontSize: '14px', border: '1px solid #ccc', borderRadius: '4px', outline: 'none' }}
+        >
+          <option value="all">All Priorities</option>
+          <option value="low">Low Priority</option>
+          <option value="medium">Medium Priority</option>
+          <option value="high">High Priority</option>
+        </select>
+      </div>
+
+      {filteredTasks.length === 0 ? (
+        <p style={{ textAlign: 'center', color: '#777' }}>
+          {tasks.length === 0 ? 'No tasks yet. Add one above!' : 'No tasks match the selected filter.'}
+        </p>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {tasks.map((task) => (
+          {filteredTasks.map((task) => (
             <li
               key={task.id}
               style={{ display: 'flex', alignItems: 'center', padding: '10px', borderBottom: '1px solid #eee', backgroundColor: task.completed ? '#f9f9f9' : 'white' }}


### PR DESCRIPTION
Added priority filtering functionality to the task manager. This includes a new filter dropdown in the UI, state management for the selected filter, and updated task rendering logic to show only tasks matching the selected priority. Also added comprehensive tests for the new feature and fixed an existing test to handle multiple comboboxes.

Fixes #3

---
*PR created automatically by Jules for task [14198212276280191342](https://jules.google.com/task/14198212276280191342) started by @Maxilicious*