### PR TITLE
Add 'Clear Completed Tasks' Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,6 +163,17 @@ export default function App() {
     setTasks(updatedTasks);
   };
 
+  const handleClearCompleted = async () => {
+    if (window.confirm('Are you sure you want to clear all completed tasks? This action cannot be undone.')) {
+      const completedTaskIds = tasks.filter(t => t.completed).map(t => t.id);
+      for (const id of completedTaskIds) {
+        await deleteTask(id);
+      }
+      const updatedTasks = await getTasks();
+      setTasks(updatedTasks);
+    }
+  };
+
   const handleStatusChange = async (id: string, status: TaskStatus) => {
     const updatedTasks = await updateTask(id, { status });
     setTasks(updatedTasks);
@@ -788,6 +799,21 @@ export default function App() {
             }}
           >
             📥 Export to CSV
+          </button>
+          <button
+            onClick={handleClearCompleted}
+            style={{
+              display: tasks.some(task => task.completed) ? 'block' : 'none',
+              padding: '8px 12px',
+              backgroundColor: theme.buttonDelete,
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '14px'
+            }}
+          >
+            Clear Completed Tasks
           </button>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '15px', flexWrap: 'wrap' }}>

--- a/src/ClearCompleted.test.tsx
+++ b/src/ClearCompleted.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import App from './App';
+
+describe('Clear Completed Tasks Functionality', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    localStorage.clear();
+    mockFetch.mockReset();
+    // Default mock for initial getTasks
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    vi.stubGlobal('confirm', vi.fn(() => true));
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the Clear Completed Tasks button only when there are completed tasks', async () => {
+    const tasks = [
+      { id: '1', title: 'Task 1', completed: false, priority: 'medium', status: 'todo' },
+      { id: '2', title: 'Task 2', completed: true, priority: 'medium', status: 'done' },
+    ];
+
+    mockFetch.mockResolvedValue({ ok: true, json: async () => tasks });
+
+    render(<App />);
+
+    // Wait for the button to be visible
+    await waitFor(() => {
+        const button = screen.queryByText('Clear Completed Tasks');
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveStyle({ display: 'block' });
+    });
+  });
+
+  it('calls deleteTask for each completed task when the button is clicked and confirmed', async () => {
+    const tasks = [
+      { id: '1', title: 'Task 1', completed: true, priority: 'medium', status: 'done' },
+      { id: '2', title: 'Task 2', completed: true, priority: 'medium', status: 'done' },
+      { id: '3', title: 'Task 3', completed: false, priority: 'medium', status: 'todo' },
+    ];
+
+    mockFetch.mockResolvedValue({ ok: true, json: async () => tasks });
+
+    render(<App />);
+
+    const clearButton = await screen.findByText('Clear Completed Tasks');
+
+    // Setup mocks for deletions and final fetch
+    mockFetch.mockResolvedValue({ ok: true, json: async () => [] }); // for DELETE and subsequent GET
+
+    fireEvent.click(clearButton);
+
+    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to clear all completed tasks? This action cannot be undone.');
+
+    await waitFor(() => {
+        // expect delete to be called for id 1 and 2
+        const deleteCalls = mockFetch.mock.calls.filter(call => call[1]?.method === 'DELETE');
+        expect(deleteCalls).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
Implemented a "Clear Completed Tasks" button in the React application. The button allows users to remove all tasks marked as completed after a confirmation prompt. It uses the existing `deleteTask` API and follows the theme's styling. Visibility is dynamically controlled based on the state of the tasks list. Unit tests have been added to ensure correct behavior.

Fixes #27

---
*PR created automatically by Jules for task [6350300028435923392](https://jules.google.com/task/6350300028435923392) started by @Maxilicious*